### PR TITLE
fix: broken unit test on toml parsing

### DIFF
--- a/rce/src/runtime/acquire.ts
+++ b/rce/src/runtime/acquire.ts
@@ -1,8 +1,20 @@
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
-import toml from "toml";
+import toml from "@ltd/j-toml";
 import { Runtime } from "./runtime";
+
+type ConfigurationFile = {
+  language: string;
+  version: string;
+  compiled: boolean;
+  extension: string;
+  build_command: string[];
+  environment: string[];
+  run_command: string[];
+  test_file: string;
+  aliases: string[];
+}
 
 export async function acquireRuntime() {
   const runtimes: Runtime[] = [];
@@ -20,7 +32,7 @@ export async function acquireRuntime() {
       );
       const configFilePath = path.resolve(packageDirPath, "config.toml");
       const configFile = await fs.readFile(configFilePath, "utf8");
-      const configObject = toml.parse(configFile);
+      const configObject = toml.parse(configFile, { joiner: "\n", bigint: false }) as ConfigurationFile;
       const runtime = new Runtime(
         configObject.language,
         configObject.version,

--- a/rce/tests/job.test.ts
+++ b/rce/tests/job.test.ts
@@ -4,41 +4,41 @@ import { Runtime } from "../src/runtime/runtime.js";
 // import { SystemUsers, User } from "../src/user/user.js";
 
 test("should throw error on invalid job parameters", (t) => {
-    const runtime = new Runtime("Javascript", "16.14.0", "js", false, [], ["node", "{file}"], ["node", "js"]);
+  const runtime = new Runtime("Javascript", "16.14.0", "js", false, [], ["node", "{file}"], ["node", "js"], {});
 
-    t.throws(
-        () => {
-            new Job({ uid: 1, gid: 1, free: false, username: "code_executor_1" }, runtime, "");
-        },
-        {
-            instanceOf: TypeError,
-            message: "Invalid job parameters"
-        }
-    );
+  t.throws(
+    () => {
+      new Job({ uid: 1, gid: 1, free: false, username: "code_executor_1" }, runtime, "");
+    },
+    {
+      instanceOf: TypeError,
+      message: "Invalid job parameters"
+    }
+  );
 });
 
 test("should give a default value for timeout and memoryLimit", (t) => {
-    const runtime = new Runtime("Javascript", "16.14.0", "js", false, [], ["node", "{file}"], ["node", "js"]);
-    const job = new Job({ uid: 1, gid: 1, free: false, username: "code_executor_1" }, runtime, "console.log(\"Hello world~\");");
+  const runtime = new Runtime("Javascript", "16.14.0", "js", false, [], ["node", "{file}"], ["node", "js"], {});
+  const job = new Job({ uid: 1, gid: 1, free: false, username: "code_executor_1" }, runtime, "console.log(\"Hello world~\");");
 
-    if (job.timeout === 5_000) {
-        t.pass("Default value for timeout is 5_000");
-    }
+  if (job.timeout === 5_000) {
+    t.pass("Default value for timeout is 5_000");
+  }
 
-    if (job.memoryLimit === 128 * 1024 * 1024) {
-        t.pass("Default value for memoryLimit is 128MB");
-    }
+  if (job.memoryLimit === 128 * 1024 * 1024) {
+    t.pass("Default value for memoryLimit is 128MB");
+  }
 });
 
 test("should not use default value for timeout and memoryLimit", (t) => {
-    const runtime = new Runtime("Javascript", "16.14.0", "js", false, [], ["node", "{file}"], ["node", "js"]);
-    const job = new Job({ uid: 1, gid: 1, free: false, username: "code_executor_1" }, runtime, "console.log(\"Hello world~\");", 10_000, 256 * 1024 * 1024);
+  const runtime = new Runtime("Javascript", "16.14.0", "js", false, [], ["node", "{file}"], ["node", "js"], {});
+  const job = new Job({ uid: 1, gid: 1, free: false, username: "code_executor_1" }, runtime, "console.log(\"Hello world~\");", 10_000, 256 * 1024 * 1024);
 
-    if (job.timeout === 10_000) {
-        t.pass("Default value for timeout is 10_000");
-    }
+  if (job.timeout === 10_000) {
+    t.pass("Default value for timeout is 10_000");
+  }
 
-    if (job.memoryLimit === 256 * 1024 * 1024) {
-        t.pass("Default value for memoryLimit is 256MB");
-    }
+  if (job.memoryLimit === 256 * 1024 * 1024) {
+    t.pass("Default value for memoryLimit is 256MB");
+  }
 });

--- a/rce/tests/runtime.test.ts
+++ b/rce/tests/runtime.test.ts
@@ -2,25 +2,25 @@ import test from "ava";
 import { Runtime } from "../src/runtime/runtime.js";
 
 test("should throw error on invalid runtime parameters", (t) => {
-    t.throws(
-        () => {
-            new Runtime("", "", "", true, [], [], []);
-        },
-        {
-            instanceOf: TypeError,
-            message: "Invalid runtime parameters"
-        }
-    );
+  t.throws(
+    () => {
+      new Runtime("", "", "", true, [], [], [], {});
+    },
+    {
+      instanceOf: TypeError,
+      message: "Invalid runtime parameters"
+    }
+  );
 });
 
 test("should throw error on invalid buildCommand parameters whilist being a compiled runtime", (t) => {
-    t.throws(
-        () => {
-            new Runtime("Maven", "1.0.0", ".xml", true, [], ["mvn", "war:explode"], ["mvn"]);
-        },
-        {
-            instanceOf: TypeError,
-            message: "Invalid runtime parameters: buildCommand is empty yet compiled is true"
-        }
-    );
+  t.throws(
+    () => {
+      new Runtime("Maven", "1.0.0", ".xml", true, [], ["mvn", "war:explode"], ["mvn"], {});
+    },
+    {
+      instanceOf: TypeError,
+      message: "Invalid runtime parameters: buildCommand is empty yet compiled is true"
+    }
+  );
 });

--- a/rce/tsconfig.json
+++ b/rce/tsconfig.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "target": "ES2019",
+    "target": "ES2021",
     "module": "ESNext",
     "declaration": false,
-    "types": [],
+    "types": [
+      "node"
+    ],
     "preserveSymlinks": true,
     "isolatedModules": true,
     "esModuleInterop": true,
@@ -24,8 +26,13 @@
     "allowJs": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["src/**/*", "stubs/**/*"]
+  "include": [
+    "src/**/*",
+    "stubs/**/*"
+  ]
 }


### PR DESCRIPTION
because the github actions hasn't been set up yet

```
❯ npm run test

> rce@0.0.1 test
> c8 ava


(node:3764) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:3764) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:3764) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  ✔ runtime › should throw error on invalid runtime parameters
  ✔ runtime › should throw error on invalid buildCommand parameters whilist being a compiled runtime
  ✔ user › should acquire a user
  ✔ user › should throw an error for invalid user range
  ✔ user › should return null when everything maxed out
  ✔ user › should be able to release a user
  ✔ job › should throw error on invalid job parameters
  ✔ job › should give a default value for timeout and memoryLimit
  ✔ job › should not use default value for timeout and memoryLimit
  ─

  9 tests passed
-------------|---------|----------|---------|---------|--------------------------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                    
-------------|---------|----------|---------|---------|--------------------------------------
All files    |    45.9 |      100 |      50 |    45.9 |                                      
 job         |   31.53 |      100 |   16.66 |   31.53 |                                      
  job.ts     |   31.53 |      100 |   16.66 |   31.53 | 68-78,81-118,121-157,160-171,174-240 
 runtime     |     100 |      100 |     100 |     100 |                                      
  runtime.ts |     100 |      100 |     100 |     100 |                                      
 user        |     100 |      100 |     100 |     100 |                                      
  user.ts    |     100 |      100 |     100 |     100 |                                      
-------------|---------|----------|---------|---------|--------------------------------------
```