### PR TITLE
fix(registratino): exclude healthz without trailing slash from submitted transaction

### DIFF
--- a/registration/Program.cs
+++ b/registration/Program.cs
@@ -29,6 +29,7 @@ builder.WebHost.UseSentry(
         options.TracesSampler = context => {
             return context.TransactionContext.Name switch {
                 "GET /healthz" => 0,
+                "GET healthz" => 0,
                 _              => 0.4
             };
 


### PR DESCRIPTION
We have around 35k dropped transactions because our performance transactions exceeds the quota.