### PR TITLE
feat(rce): bump packages

### DIFF
--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -179,22 +179,22 @@ const responseExample = `
 		<p>The Pesto REST API currently supports the following runtimes:</p>
 		<FieldList
 			items={[
-				{ key: "Python", value: "v3.10.10" },
+				{ key: "Python", value: "v3.12.0" },
 				{ key: "Java", value: "OpenJDK 17" },
 				{ key: "C/C++", value: "GCC v12.2.0" },
 				{ key: "Common Lisp", value: "SBCL v2.2.7" },
 				{ key: "Elixir", value: "v1.14.1" },
 				{ key: "Erlang", value: "v25.1.2" },
-				{ key: "Go", value: "v1.20.2" },
-				{ key: "Javascript", value: "Node v18.12.1" },
-				{ key: "Typescript", value: "Bun v0.6.5" },
+				{ key: "Go", value: "v1.21.4" },
+				{ key: "Javascript", value: "Node v20.9.0" },
+				{ key: "Typescript", value: "Bun v1.0.13" },
 				{ key: "PHP", value: "v8.1" },
 				{
 					key: "Brainfuck",
 					value: "v2.7.3",
 				},
 				{ key: "Ruby", value: "v3.2.1" },
-				{ key: "Julia", value: "v1.7.3" },
+				{ key: "Julia", value: "v1.9.4" },
 				{ key: "Lua", value: "v5.4.4" },
 				{ key: "Janet", value: "v1.27.0" },
 				{ key: "SQLite3", value: "3.34.1" },

--- a/rce/packages/go/config.toml
+++ b/rce/packages/go/config.toml
@@ -1,13 +1,13 @@
 language = "Go"
-version = "1.20.2"
+version = "1.21.4"
 compiled = true
 extension = "go"
-build_command = [ "/opt/go/1.20/go/bin/go", "build", "-o", "code", "{file}"]
+build_command = [ "/opt/go/1.21/go/bin/go", "build", "-o", "code", "{file}"]
 run_command = [ "./code" ]
 test_file = "test.go"
-environment = [ "GOPATH=/opt/go/1.20/go", "PATH=/opt/go/1.20/go/bin" ]
+environment = [ "GOPATH=/opt/go/1.21/go", "PATH=/opt/go/1.21/go/bin" ]
 aliases = [ "go", "golang" ]
 should_limit_memory = false
 memory_limit = 0
-process_limit = 2048
+process_limit = 4096
 allowed_entrypoints = -1

--- a/rce/packages/go/install.sh
+++ b/rce/packages/go/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-VERSION="1.20.2"
+VERSION="1.21.4"
 
 cd ~
 curl -LO https://go.dev/dl/go${VERSION}.linux-amd64.tar.gz
-mkdir -p /opt/go/1.20
-tar -C /opt/go/1.20 -xzf go${VERSION}.linux-amd64.tar.gz
+mkdir -p /opt/go/1.21
+tar -C /opt/go/1.21 -xzf go${VERSION}.linux-amd64.tar.gz
 rm go${VERSION}.linux-amd64.tar.gz

--- a/rce/packages/javascript-20/config.toml
+++ b/rce/packages/javascript-20/config.toml
@@ -1,0 +1,13 @@
+language = "Javascript"
+version = "20.9.0"
+compiled = false
+extension = "js"
+environment = [ "PATH=/opt/node/20.9.0/bin"]
+build_command = []
+run_command = [ "/opt/node/20.9.0/bin/node", "{file}" ]
+test_file = "test.js"
+aliases = ["javascript", "js"]
+should_limit_memory = true
+memory_limit = 1024
+process_limit = 1024
+allowed_entrypoints = 1

--- a/rce/packages/javascript-20/install.sh
+++ b/rce/packages/javascript-20/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+VERSION="20.9.0"
+
+cd ~
+curl -LO https://nodejs.org/dist/v${VERSION}/node-v${VERSION}-linux-x64.tar.gz
+tar -zxf node-v${VERSION}-linux-x64.tar.gz
+
+mkdir --parents --verbose /opt/node/${VERSION}/
+
+mv -v node-v${VERSION}-linux-x64/* /opt/node/${VERSION}/
+
+rm -rf node-v${VERSION}-linux-x64 node-v${VERSION}-linux-x64.tar.gz

--- a/rce/packages/javascript-20/test.js
+++ b/rce/packages/javascript-20/test.js
@@ -1,0 +1,1 @@
+console.log("Hello world!");

--- a/rce/packages/julia/config.toml
+++ b/rce/packages/julia/config.toml
@@ -1,10 +1,10 @@
 language = "Julia"
-version = "1.7.3"
+version = "1.9.4"
 compiled = false
 extension = "jl"
-environment = [ "PATH=/opt/julia/1.7/bin" ]
+environment = [ "PATH=/opt/julia/1.9/bin" ]
 build_command = []
-run_command = [ "/opt/julia/1.7/bin/julia", "{file}" ]
+run_command = [ "/opt/julia/1.9/bin/julia", "{file}" ]
 test_file = "test.jl"
 aliases = ["jl"]
 should_limit_memory = false

--- a/rce/packages/julia/install.sh
+++ b/rce/packages/julia/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-MINOR="1.7"
-VERSION="1.7.3"
+MINOR="1.9"
+VERSION="1.9.4"
 
 cd ~
 curl -LO https://julialang-s3.julialang.org/bin/linux/x64/${MINOR}/julia-${VERSION}-linux-x86_64.tar.gz
 tar zxvf julia-${VERSION}-linux-x86_64.tar.gz
 mv -v julia-${VERSION} julia
 mkdir -p /opt/julia/
-mv -v julia /opt/julia/1.7
+mv -v julia /opt/julia/1.9
 rm julia-${VERSION}-linux-x86_64.tar.gz

--- a/rce/packages/python/config.toml
+++ b/rce/packages/python/config.toml
@@ -1,10 +1,10 @@
 language = "Python"
-version = "3.10.10"
+version = "3.12.0"
 compiled = false
 extension = "py"
-environment = [ "PATH=/opt/python/3.10.10/bin" ]
+environment = [ "PATH=/opt/python/3.12.0/bin" ]
 build_command = []
-run_command = [ "/opt/python/3.10.10/bin/python3", "{file}" ]
+run_command = [ "/opt/python/3.12.0/bin/python3", "{file}" ]
 test_file = "test.py"
 aliases = ["python", "py"]
 should_limit_memory = true

--- a/rce/packages/python/install.sh
+++ b/rce/packages/python/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="3.10.10"
+VERSION="3.12.0"
 
 cd /tmp
 # Acquire the Python tar.gz file from the source repository

--- a/rce/packages/typescript-bun/config.toml
+++ b/rce/packages/typescript-bun/config.toml
@@ -1,10 +1,10 @@
 language = "Typescript"
-version = "0.6.5"
+version = "1.0.13"
 compiled = false
 extension = "ts"
-environment = [ "PATH=/opt/bun/0.6.5"]
+environment = [ "PATH=/opt/bun/1.0.13"]
 build_command = []
-run_command = [ "/opt/bun/0.6.5/bun", "{file}" ]
+run_command = [ "/opt/bun/1.0.13/bun", "{file}" ]
 test_file = "test.ts"
 aliases = ["typescript", "ts"]
 should_limit_memory = false

--- a/rce/packages/typescript-bun/install.sh
+++ b/rce/packages/typescript-bun/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-mkdir -p /opt/bun/0.6.5
-curl -LO https://github.com/oven-sh/bun/releases/download/bun-v0.6.5/bun-linux-x64.zip
+mkdir -p /opt/bun/1.0.13
+curl -LO https://github.com/oven-sh/bun/releases/download/bun-v1.0.13/bun-linux-x64.zip
 unzip bun-linux-x64.zip
-mv bun-linux-x64/bun /opt/bun/0.6.5/bun
+mv bun-linux-x64/bun /opt/bun/1.0.13/bun
 rm -rf bun-linux-x64.zip bun-linux-x64


### PR DESCRIPTION
Bump:
* Python from 3.10.10 to 3.12.0
* Go from 1.20.2 to 1.21.4
* Javascript (added) 20.9.0, all previous v16 and v18 still exists
* Typescript (Bun) from 0.6.5 to 1.0.13
* Julia from 1.7.3 to 1.9.4