### PR TITLE
chore(analytics): update website id

### DIFF
--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -26,7 +26,7 @@ import "@fontsource/ibm-plex-mono/400.css";
 		<script
 			async
 			src="https://analytics.teknologiumum.com/script.js"
-			data-website-id="a5794a69-73a6-4444-8865-7428e2f64759"></script>
+			data-website-id="876668cd-4e93-4330-a8cf-6c52765d6db5"></script>
 	</head>
 	<body>
 		<div id="app">


### PR DESCRIPTION
I did something wrong on the deployment upgrade, everything was reset. We need to change the analytics website id in order to get it back working again.